### PR TITLE
Fix typo in sat5cfg2ansible script

### DIFF
--- a/sat5cfg2ansible.py
+++ b/sat5cfg2ansible.py
@@ -114,7 +114,7 @@ for file in json_files:
                 with open(AnsibleFileToWrite, 'a') as yaml_file:
                     configuration = yaml.dump(create_directory_template, yaml_file, sort_keys=False)
 
-        # cvs file
+        # CSV file
         CSV_FILE_PATH = RoleDirectory + "/" + AnsibleRoleName + "_checklist.csv"
         csv_file = open(CSV_FILE_PATH, 'w', newline='')
         writer = csv.writer(csv_file, delimiter=';')


### PR DESCRIPTION
## Summary
- fix comment typo in sat5cfg2ansible.py

## Testing
- `python -m py_compile sat5cfg2ansible.py`
