### PR TITLE
Fix symlink description

### DIFF
--- a/sat5cfg2ansible.py
+++ b/sat5cfg2ansible.py
@@ -175,7 +175,7 @@ for file in json_files:
             if i['type'] == 'symlink':
                 SYMLINK_SOURCE = i['path']
                 SYMLINK_DESTINATION = i['target_path']
-                TASK_DESCRIPTION = "Create directory " + SYMLINK_DESTINATION
+                TASK_DESCRIPTION = "Create symlink " + SYMLINK_DESTINATION
 
                 create_symlink_template = [
                     {


### PR DESCRIPTION
## Summary
- fix wording for symlink tasks

## Testing
- `python -m py_compile sat5cfg2ansible.py`
