### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Converting Red Hat Satellite 5 Configuration Channels to Ansible Roles
 
-This script converts Red Hat Satellite 5 configuration channels to ansible roles.
+This script converts Red Hat Satellite 5 configuration channels to Ansible roles.
 
 ## Usage
 
@@ -33,7 +33,6 @@ podman build -t sat5cfg .
 
 To convert the JSON files using the container, run the following command:
 
-Copy code
 
 `podman run -it -v <path_to_local_files>:/data:Z sat5cfg`
 


### PR DESCRIPTION
## Summary
- capitalize Ansible in intro
- remove stray "Copy code" line

## Testing
- `python -m py_compile sat5cfg2ansible.py`